### PR TITLE
Optimizations

### DIFF
--- a/osm/style.less
+++ b/osm/style.less
@@ -1,9 +1,3 @@
-Map {
-  background-color: @background;
-  south-pole-color: @background;
-  north-pole-color: @water;
-  font-directory: url(../fonts/);
-}
 //CARTO Fonts
 @mont: 'DIN Pro Regular';
 @mont_md: 'DIN Pro Medium';
@@ -324,7 +318,7 @@ Map {
 @saddle_icon:[nuti::osm-saddle];
 @peak_icon_width: @poi_icon_width;
 @peak_label_width: linear([view::zoom], (5, 5), (10, 7), (18, 10)) - 0.000001 * [rank];
-@peak_label_dy: linear([view::zoom], (5, 6), (10, 8), (18, 12));
+@peak_label_dy: @poi_label_dy;
 @peak_text_min_dist: linear([view::zoom], (5, 30), (10, 20), (18, 10));
 
 /* 6.3 Place labels */
@@ -407,6 +401,6 @@ Map {
 @poi_national_park_label_width:linear([view::zoom], (5, 8), (10, 11), (18, 12)) - 0.000001 * [rank];
 @poi_label_wrap_width:linear([view::zoom], (14, 50), (18, 100));
 @poi_national_park_wrap_width:linear([view::zoom], (14, 60), (18, 100));
-@poi_label_dy: linear([view::zoom], (10, 10), (12, 11), (19, 13), (20, 18));
+@poi_label_dy: linear([view::zoom], (10, 10), (12, 11), (18, 14), (19, 15), (20, 16));
 
 @peak_label_width: linear([view::zoom], (5, 5), (10, 7), (18, 10)) - 0.000001 * [rank];

--- a/outdoors/style.less
+++ b/outdoors/style.less
@@ -1,9 +1,3 @@
-Map {
-  background-color: @background;
-  south-pole-color: @background;
-  north-pole-color: @water;
-  font-directory: url(../fonts/);
-}
 //CARTO Fonts
 @mont: 'DIN Pro Regular';
 @mont_md: 'DIN Pro Medium';
@@ -400,4 +394,4 @@ Map {
 @poi_national_park_label_width:@poi_icon_width;
 @poi_national_park_wrap_width:@poi_label_wrap_width;
 @poi_label_wrap_width:step([view::zoom], (14, 60), (18, 100));
-@poi_label_dy: linear([view::zoom], (10, 12), (18, 13));
+@poi_label_dy: linear([view::zoom], (10, 10), (12, 11), (18, 14), (19, 15), (20, 16));

--- a/shared/labels.less
+++ b/shared/labels.less
@@ -1,7 +1,6 @@
 
 @name: [nuti::lang] ? ([name:[nuti::lang]] ? [name:[nuti::lang]] : ([name:[nuti::fallback_lang]] ? [name:[nuti::fallback_lang]] : [name])) : [name];
 @osm_icon: [nuti::osm-[subclass]] ? [nuti::osm-[subclass]] : ([nuti::osm-[class]]?[nuti::osm-[class]]:[nuti::osm-symbol-dot]);
-@featureId: [osmid];
 
 #mountain_peak {
 	// order is important for icon to take precedence over label and respect rank
@@ -15,7 +14,6 @@
 			text-name: @saddle_icon;
 			text-fill: @sadle_label;
 		}
-		text-feature-id: @featureId;
 	}
 	[class=peak]::text, 
 	[zoom>=12]::text {
@@ -33,7 +31,6 @@
 		}
 		text-dy: @peak_label_dy; 
 		text-wrap-width: @poi_label_wrap_width;
-		text-feature-id: @featureId;
 		text-halo-fill: @peak_halo;
 		text-halo-radius: @peak_halo_radius;
 		text-min-distance: @peak_text_min_dist;
@@ -424,7 +421,6 @@
 			text-name: @osm_icon;
 			text-size: @poi_icon_width;
 			text-face-name: @osm;
-			text-feature-id: @featureId;
 			text-halo-fill: @poi_halo;
 			text-halo-radius: @poi_halo_radius;
 			text-fill: @poi-lodging-fill;
@@ -438,7 +434,6 @@
 			text-halo-radius: @poi_halo_radius;
 			text-size: @poi_label_width;
 			text-wrap-width: @poi_label_wrap_width;
-			text-feature-id: @featureId;
 			text-dy: @poi_label_dy;
 			text-fill: darken(@poi-lodging-fill, 10%);
 		}
@@ -452,7 +447,6 @@
 			text-name: @osm_icon;
 			text-size: @poi_icon_width;
 			text-face-name: @osm;
-			text-feature-id: @featureId;
 			text-halo-fill: @poi_halo;
 			text-halo-radius: @poi_halo_radius;
 			text-size: linear([view::zoom], (18, 10), (20, 14.0)) - 0.0000011 * [rank];
@@ -467,7 +461,6 @@
 			text-halo-radius: @poi_halo_radius;
 			text-size: @poi_label_width;
 			text-wrap-width: @poi_label_wrap_width;
-			text-feature-id: @featureId;
 			text-dy: @poi_label_dy;
 			text-fill: darken(@poi-campsite-fill, 30%);
 		}
@@ -479,7 +472,6 @@
 		text-name: @osm_icon;
 		text-size: @poi_icon_width;
 		text-face-name: @osm;
-		text-feature-id: @featureId;
 		text-halo-fill: @poi_halo;
 		text-halo-radius: @poi_halo_radius;
 		text-fill: @poi-water-fill;
@@ -495,7 +487,6 @@
 		text-halo-radius: @poi_halo_radius;
 		text-size: @poi_label_width;
 		text-wrap-width: @poi_label_wrap_width;
-		text-feature-id: @featureId;
 		text-dy: @poi_label_dy;
 		text-fill: darken(@poi-water-fill, 30%);
 		text-size: @poi-spring-size;
@@ -511,7 +502,6 @@
 			text-name: @osm_icon;
 			text-size: @poi_icon_width;
 			text-face-name: @osm;
-			text-feature-id: @featureId;
 			text-halo-fill: @poi_halo;
 			text-halo-radius: @poi_halo_radius;
 			text-fill: @poi-fill;
@@ -558,7 +548,6 @@
 				text-halo-radius: @poi_halo_radius;
 				text-size: @poi_label_width;
 				text-wrap-width: @poi_label_wrap_width;
-				text-feature-id: @featureId;
 				text-dy: @poi_label_dy;
 				text-fill: @poi-fill;
 				[class=park] {
@@ -604,7 +593,6 @@
 		text-name: [nuti::osm-park];
 		text-size: @poi_icon_width;
 		text-face-name: @osm;
-		text-feature-id: @featureId;
 		text-halo-fill: @poi_halo;
 		text-halo-radius: @poi_halo_radius;
 		text-fill: @poi-park-fill;
@@ -617,7 +605,6 @@
 			text-fill: darken(@poi-park-fill, 30%);
 			text-halo-fill: @poi_halo;
 			text-halo-radius: @poi_halo_radius;
-			text-feature-id: @featureId;
 			text-dy: @poi_label_dy;
 			text-size:@poi_national_park_label_width;
 			text-wrap-width: @poi_national_park_wrap_width;

--- a/shared/landuse.less
+++ b/shared/landuse.less
@@ -1,10 +1,12 @@
 @name: [nuti::lang] ? ([name:[nuti::lang]] ? [name:[nuti::lang]] : ([name:[nuti::fallback_lang]] ? [name:[nuti::fallback_lang]] : [name])) : [name];
+
 Map {
   background-color: @background;
   south-pole-color: @background;
   north-pole-color: @water;
-	font-directory: url(fonts/);
+  font-directory: url(fonts/);
 }
+
 #landcover['mapnik::geometry_type'=3] {
   [class=tidalflat] {
     polygon-fill: @mud;
@@ -279,5 +281,4 @@ Map {
   [class=apron] {
     polygon-fill: @apron-fill;
   }
-
 }

--- a/streets/style.less
+++ b/streets/style.less
@@ -1,9 +1,3 @@
-Map {
-  background-color: @background;
-  south-pole-color: @background;
-  north-pole-color: @water;
-  font-directory: url(../fonts/);
-}
 //CARTO Fonts
 @mont: 'DIN Pro Regular';
 @mont_md: 'DIN Pro Medium';
@@ -397,4 +391,4 @@ Map {
 @poi_label_width:linear([view::zoom], (10, 11), (18, 12)) - 0.000001 * [rank];
 @poi_label_wrap_width:step([view::zoom], (14, 60), (18, 100));
 @poi_national_park_wrap_width:@poi_label_wrap_width;
-@poi_label_dy: linear([view::zoom], (10, 12), (18, 13));
+@poi_label_dy: linear([view::zoom], (10, 10), (12, 11), (18, 14), (19, 15), (20, 16));


### PR DESCRIPTION
Two tweaks/fixes:

* Drop `text-feature-id` usage. This simply does not work, as `[osmid]` attribute is missing from tiles. This field is stored already as feature id, thus no custom `text-feature-id` setting is required. This improves performance and fixes minor flickering when replacing tiles.
* Tweak `text-dy` attribute usage for POIs. At higher zoom levels POI names were hidden due to collisions with icons.